### PR TITLE
set conditions for failed transaction screen

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -97,7 +97,8 @@
         "done": "Done",
         "exit": "Exit",
         "simulating": "Simulating...",
-        "transaction-completed": "Transaction completed"
+        "transaction-completed": "Transaction completed",
+        "transaction-failed": "Transaction failed"
       },
       "supply": "Supply",
       "to-gauge": "To gauge",

--- a/src/client/components/app/Transactions/DeployLineTx.tsx
+++ b/src/client/components/app/Transactions/DeployLineTx.tsx
@@ -59,6 +59,14 @@ export const DeployLineTx: FC<DeployLineProps> = (props) => {
     setTimeToLive(timeToLive.toString());
   };
 
+  const onTransactionCompletedDismissed = () => {
+    if (onClose) {
+      onClose();
+    } else {
+      setTransactionCompleted(0);
+    }
+  };
+
   const onBorrowerChange = (address: string) => {
     setBorrower(address);
   };
@@ -81,11 +89,14 @@ export const DeployLineTx: FC<DeployLineProps> = (props) => {
 
     try {
       dispatch(LinesActions.deploySecuredLine({ borrower, ttl: timeToLive })).then((res) => {
-        if (res.type !== 'lines/deploySecuredLine/rejected') {
-          setTransactionCompleted(1);
-          setLoading(false);
-        } else if (res.type === 'lines/deploySecuredLine/rejected') {
+        if (res.meta.requestStatus === 'rejected') {
           setTransactionCompleted(2);
+          console.log(transactionCompleted, 'tester');
+          setLoading(false);
+        }
+        if (res.meta.requestStatus === 'fulfilled') {
+          setTransactionCompleted(1);
+          console.log(transactionCompleted, 'tester');
           setLoading(false);
         }
       });
@@ -96,16 +107,26 @@ export const DeployLineTx: FC<DeployLineProps> = (props) => {
 
   if (transactionCompleted === 1) {
     return (
-      <StyledTransaction onClose={onClose} header={''}>
-        <TxStatus transactionCompletedLabel={'deployed line successfully'} exit={() => {}} />
+      <StyledTransaction onClose={onClose} header={'Transaction complete'}>
+        {console.log(transactionCompleted)}
+        <TxStatus
+          success={transactionCompleted}
+          transactionCompletedLabel={'deployed line successfully'}
+          exit={onTransactionCompletedDismissed}
+        />
       </StyledTransaction>
     );
   }
 
   if (transactionCompleted === 2) {
     return (
-      <StyledTransaction>
-        <TxStatus transactionCompletedLabel={'Could not deploy line'} exit={() => {}} />
+      <StyledTransaction onClose={onClose} header={'Transaction failed'}>
+        {console.log(transactionCompleted)}
+        <TxStatus
+          success={transactionCompleted}
+          transactionCompletedLabel={'Could not deploy line'}
+          exit={onTransactionCompletedDismissed}
+        />
       </StyledTransaction>
     );
   }

--- a/src/client/components/app/Transactions/Transaction.tsx
+++ b/src/client/components/app/Transactions/Transaction.tsx
@@ -100,7 +100,11 @@ export const Transaction: FC<TransactionProps> = (props) => {
   if (transactionCompleted) {
     return (
       <StyledTransaction onClose={onClose} header={transactionLabel}>
-        <TxStatus transactionCompletedLabel={transactionCompletedLabel} exit={onTransactionCompletedDismissed} />
+        <TxStatus
+          success={1}
+          transactionCompletedLabel={transactionCompletedLabel}
+          exit={onTransactionCompletedDismissed}
+        />
       </StyledTransaction>
     );
   }

--- a/src/client/components/app/Transactions/components/TxStatus.tsx
+++ b/src/client/components/app/Transactions/components/TxStatus.tsx
@@ -2,7 +2,7 @@ import { FC } from 'react';
 import styled from 'styled-components';
 
 import { useAppTranslation } from '@hooks';
-import { CheckRoundIcon, Text, Icon } from '@components/common';
+import { CheckRoundIcon, Text, Icon, ErrorIcon } from '@components/common';
 
 import { TxActionButton, TxActions } from './TxActions';
 
@@ -31,6 +31,20 @@ const TxStatusContent = styled.div`
   gap: 6.9rem;
 `;
 
+const TxStatusContentFail = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  color: ${({ theme }) => theme.colors.txModalColors.error};
+  background: ${({ theme }) => theme.colors.txModalColors.backgroundVariant};
+  border-radius: ${({ theme }) => theme.globalRadius};
+  padding-top: 6.4rem;
+  padding-bottom: 16.8rem;
+  fill: currentColor;
+  gap: 6.9rem;
+`;
+
 const StyledTxStatus = styled.div`
   display: flex;
   flex-direction: column;
@@ -40,27 +54,45 @@ const StyledTxStatus = styled.div`
 export interface TxStatusProps {
   transactionCompletedLabel?: string;
   exit: () => void;
+  success: number;
 }
 
-export const TxStatus: FC<TxStatusProps> = ({ transactionCompletedLabel, exit, children, ...props }) => {
+// Pass down 2 as props for failed transactions and 1 for successful transactions
+
+export const TxStatus: FC<TxStatusProps> = ({ transactionCompletedLabel, success, exit, children, ...props }) => {
   const { t } = useAppTranslation('common');
 
   const actionButtonLabel = transactionCompletedLabel ?? t('components.transaction.status.exit');
 
   return (
     <StyledTxStatus {...props}>
-      <TxStatusContent>
-        <StyledText>{t('components.transaction.status.transaction-completed')}</StyledText>
-
-        <StyledIcon Component={CheckRoundIcon} />
-      </TxStatusContent>
-
-      <TxActions>
-        <TxActionButton onClick={exit} success>
-          {actionButtonLabel}
-        </TxActionButton>
-      </TxActions>
-
+      {success === 1 ? (
+        <>
+          <TxStatusContent>
+            <StyledText>{t('components.transaction.status.transaction-completed')}</StyledText>
+            <StyledIcon Component={CheckRoundIcon} />
+          </TxStatusContent>
+          <TxActions>
+            <TxActionButton onClick={exit} success>
+              {actionButtonLabel}
+            </TxActionButton>
+          </TxActions>
+        </>
+      ) : success === 2 ? (
+        <>
+          <TxStatusContentFail>
+            <StyledText>{t('components.transaction.status.transaction-failed')}</StyledText>
+            <StyledIcon Component={ErrorIcon} />
+          </TxStatusContentFail>
+          <TxActions>
+            <TxActionButton onClick={exit} success={false}>
+              {actionButtonLabel}
+            </TxActionButton>
+          </TxActions>
+        </>
+      ) : (
+        ''
+      )}
       {children}
     </StyledTxStatus>
   );


### PR DESCRIPTION
## Description

Adding fail screens to transactions for better UX
- added to deploy line
- added to addCredit

## Related Issue

[Related Notion issue here](https://www.notion.so/Update-error-handling-on-modals-for-failed-tx-e960c0f44e4a4c049c4c0902ec9d4804)

## Motivation and Context

Properly display errors on modals when a transaction fails to send. 

For example with this DeployLineTx modal I didn't have a wallet connected (i refused connection to the domain on my wallet) yet the UI said this tx succeeded. when none was ever even sent.

## How Has This Been Tested?

Manual testing on all related TX

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/69639595/194841604-ef5d99e4-4ed8-4ccc-9601-bff73b2748b2.png)
