### PR TITLE
borrow UX improvements and testing

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -160,8 +160,9 @@
       },
       "borrow-credit": {
         "header": "Borrow",
-        "select-line": "1. Select a Lender's Offer.",
-        "select-amount": "2. Select amount to borrow"
+        "select-line": "1. Select a Position:",
+        "select-amount": "2. Select Token and Amount:",
+        "your-rates": "3. Your Rates:"
       },
       "deposit-and-repay": {
         "header": "Repay",

--- a/src/client/components/app/Transactions/BorrowCreditTx.tsx
+++ b/src/client/components/app/Transactions/BorrowCreditTx.tsx
@@ -4,6 +4,7 @@ import { ethers } from 'ethers';
 
 import { useAppTranslation, useAppDispatch, useAppSelector } from '@hooks';
 import { LinesSelectors, LinesActions, WalletSelectors } from '@store';
+import { normalizeAmount } from '@src/utils';
 
 import { TxContainer } from './components/TxContainer';
 import { TxCreditLineInput } from './components/TxCreditLineInput';
@@ -11,6 +12,7 @@ import { TxActionButton } from './components/TxActions';
 import { TxActions } from './components/TxActions';
 import { TxStatus } from './components/TxStatus';
 import { TxTTLInput } from './components/TxTTLInput';
+import { TxRateInput } from './components/TxRateInput';
 
 const StyledTransaction = styled(TxContainer)``;
 
@@ -31,6 +33,7 @@ export const BorrowCreditTx: FC<BorrowCreditProps> = (props) => {
   const [transactionCompleted, setTransactionCompleted] = useState(0);
   const [transactionLoading, setLoading] = useState(false);
   const walletNetwork = useAppSelector(WalletSelectors.selectWalletNetwork);
+  const selectedPosition = useAppSelector(LinesSelectors.selectPositionData);
   const [targetAmount, setTargetAmount] = useState('1');
   const selectedCredit = useAppSelector(LinesSelectors.selectSelectedLine);
   const setSelectedCredit = (lineAddress: string) => dispatch(LinesActions.setSelectedLineAddress({ lineAddress }));
@@ -64,17 +67,18 @@ export const BorrowCreditTx: FC<BorrowCreditProps> = (props) => {
   const borrowCredit = () => {
     setLoading(true);
     // TODO set error in state to display no line selected
-    if (!selectedCredit?.id || !targetAmount || walletNetwork === undefined) {
+    if (!selectedCredit?.id || !targetAmount || walletNetwork === undefined || selectedPosition === undefined) {
       setLoading(false);
       return;
     }
 
     dispatch(
       LinesActions.borrowCredit({
-        lineAddress: selectedCredit.id,
+        line: selectedCredit.id,
+        positionId: selectedPosition[0]['id'],
         amount: ethers.utils.parseEther(targetAmount),
         network: walletNetwork,
-        dryRun: true,
+        dryRun: false,
       })
     ).then((res) => {
       if (res.meta.requestStatus === 'rejected') {
@@ -98,7 +102,7 @@ export const BorrowCreditTx: FC<BorrowCreditProps> = (props) => {
     },
   ];
 
-  if (!selectedCredit) return null;
+  if (!selectedCredit || selectedPosition === undefined) return null;
 
   if (transactionCompleted === 1) {
     return (
@@ -143,13 +147,24 @@ export const BorrowCreditTx: FC<BorrowCreditProps> = (props) => {
         inputError={false}
         amount={targetAmount}
         onAmountChange={onAmountChange}
-        maxAmount={'0'}
+        maxAmount={normalizeAmount(selectedPosition[0]['deposit'], 18)}
         maxLabel={'Max'}
         readOnly={false}
         hideAmount={false}
         loading={false}
         loadingText={''}
         ttlType={false}
+      />
+      <TxRateInput
+        key={'frate'}
+        headerText={t('components.transaction.borrow-credit.your-rates')}
+        frate={selectedPosition[0]['frate']}
+        drate={selectedPosition[0]['drate']}
+        amount={selectedPosition[0]['frate']}
+        maxAmount={'100'}
+        // setRateChange={onFrateChange}
+        setRateChange={() => {}}
+        readOnly={true}
       />
       <TxActions>
         {txActions.map(({ label, onAction, status, disabled, contrast }) => (

--- a/src/core/services/CreditLineService.ts
+++ b/src/core/services/CreditLineService.ts
@@ -257,10 +257,10 @@ export class CreditLineServiceImpl implements CreditLineService {
 
   public async borrow(props: BorrowCreditProps): Promise<TransactionResponse | PopulatedTransaction> {
     try {
-      const line = props.lineAddress;
+      const line = props.line;
 
       let data = {
-        id: props.lineAddress,
+        id: props.positionId,
         amount: props.amount,
       };
       //@ts-ignore

--- a/src/core/store/modules/lines/lines.actions.ts
+++ b/src/core/store/modules/lines/lines.actions.ts
@@ -247,17 +247,18 @@ const approveDeposit = createAsyncThunk<
 
 const borrowCredit = createAsyncThunk<void, BorrowCreditProps, ThunkAPI>(
   'lines/borrowCredit',
-  async ({ lineAddress, amount, network }, { extra, getState }) => {
+  async ({ positionId, amount, network, line }, { extra, getState }) => {
     const { wallet } = getState();
     const { services } = extra;
-    console.log('look at borrow credit', wallet, lineAddress, amount);
+    console.log('look at borrow credit', wallet, positionId, amount, line);
     const { creditLineService } = services;
 
     const tx = await creditLineService.borrow({
-      lineAddress: lineAddress,
+      line: line,
+      positionId: positionId,
       amount: amount,
       network: network,
-      dryRun: true,
+      dryRun: false,
     });
     console.log(tx);
   }

--- a/src/core/types/Service.ts
+++ b/src/core/types/Service.ts
@@ -209,7 +209,8 @@ export interface AddCreditProps {
 }
 
 export interface BorrowCreditProps {
-  lineAddress: string;
+  line: string;
+  positionId: string;
   amount: BigNumber;
   network: Network;
   dryRun: boolean;


### PR DESCRIPTION
## Description

Added a read-only display for interest Rates, changed Max Amount button, use PositionID to call borrow function

## Related Issue

[update modals epic](https://www.notion.so/Update-modals-038a058a39784393b1aa55b2beaf7373)

## Motivation and Context

Allow borrow to draw down on an LoC

## How Has This Been Tested?

Manual testing, TX fails as of now.

## Screenshots (if appropriate):

**
![image](https://user-images.githubusercontent.com/69639595/200537903-8d629b0c-b672-4880-80f7-f6e705d87692.png)
**
