### PR TITLE
adding a dropdown input field to switch between repayment actions, th…

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -81,7 +81,9 @@
       "approve": "Approve",
       "available-borrow": "Available to borrow",
       "borrow": "Borrow",
-      "deposit-and-repay-header": "deposit and repay",
+      "deposit-and-repay-header": "Deposit and Repay",
+      "claim-and-repay-header": "Claim and Repay",
+      "deposit-and-close-header": "Deposit and Close",
       "withdraw": "Withdraw",
       "borrow-limit": {
         "borrow-apy": "Borrow APY",
@@ -167,8 +169,10 @@
       "deposit-and-repay": {
         "header": "Repay",
         "select-position": "1. Select Position to Repay:",
-        "select-amount": "2. You Owe:",
-        "your-rates": "3. Your Interest Rates:"
+        "repay-type": "2. Select Repay Type:",
+        "select-amount": "3. You Owe:",
+        "your-rates": "4. Your Interest Rates:",
+        "select-repay": "Select Repayment Method"
       },
       "withdraw-credit": {
         "header": "Withdraw",

--- a/src/client/components/app/Transactions/components/TxDropdown.tsx
+++ b/src/client/components/app/Transactions/components/TxDropdown.tsx
@@ -1,0 +1,225 @@
+import { FC, useState } from 'react';
+import styled from 'styled-components';
+import { CSSTransition, TransitionGroup } from 'react-transition-group';
+
+import { useAppTranslation } from '@hooks';
+import { Text, Icon, SearchList, ZapIcon, SearchListItem, WalletIcon } from '@components/common';
+
+const LineTitle = styled(Text)`
+  color: ${({ theme }) => theme.colors.txModalColors.text};
+  fontsize: large;
+`;
+
+const CreditLineData = styled.div`
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border-radius: ${({ theme }) => theme.globalRadius};
+  background: ${({ theme }) => theme.colors.txModalColors.backgroundVariant};
+  padding: ${({ theme }) => theme.layoutPadding};
+  font-size: 1.7rem;
+  flex: 1;
+`;
+
+const StyledIcon = styled(Icon)`
+  width: 6.4rem;
+  padding: 1rem;
+`;
+
+const CreditLineName = styled.div`
+  width: 100%;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  text-align: center;
+  font-size: 1.3rem;
+  max-height: 3rem;
+`;
+
+const CreditLineListIcon = styled(Icon)`
+  position: absolute;
+  top: 0.8rem;
+  right: 0.4rem;
+  color: ${({ theme }) => theme.colors.txModalColors.onBackgroundVariantColor};
+`;
+
+const CreditLineIconContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+`;
+
+const CreditLineSelector = styled.div<{ onClick?: () => void; center?: boolean }>`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: ${({ center }) => (center ? '100%' : '8.4rem')};
+  height: ${({ center }) => (center ? '12.6rem' : undefined)};
+  border-radius: ${({ theme }) => theme.globalRadius};
+  background: ${({ theme }) => theme.colors.txModalColors.backgroundVariant};
+  color: ${({ theme }) => theme.colors.txModalColors.textContrast};
+  fill: ${({ theme }) => theme.colors.txModalColors.text};
+  flex-shrink: 0;
+  padding: 0 0.7rem;
+  gap: 0.7rem;
+  user-select: none;
+  position: relative;
+  ${({ onClick }) => onClick && 'cursor: pointer;'}
+`;
+
+const CreditLineInfo = styled.div<{ center?: boolean }>`
+  display: flex;
+  justify-content: ${({ center }) => (center ? 'center' : 'flex-start')};
+  gap: ${({ theme }) => theme.txModal.gap};
+  overflow: hidden;
+`;
+
+const StyledSearchList = styled(SearchList)`
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  left: 0;
+  top: 0;
+  transform-origin: bottom left;
+`;
+
+const Header = styled.div`
+  font-size: 1.6rem;
+  text-transform: capitalize;
+  color: ${({ theme }) => theme.colors.txModalColors.text};
+`;
+
+const scaleTransitionTime = 300;
+
+const StyledTxCreditLineInput = styled(TransitionGroup)`
+  display: grid;
+  // min-height: 15.6rem;
+  width: 100%;
+  border-radius: ${({ theme }) => theme.globalRadius};
+  grid-gap: 0.8rem;
+  cursor: pointer;
+
+  .scale-enter {
+    opacity: 0;
+    transform: scale(0);
+    transition: opacity ${scaleTransitionTime}ms ease, transform ${scaleTransitionTime}ms ease;
+  }
+
+  .scale-enter-active {
+    opacity: 1;
+    transform: scale(1);
+  }
+
+  .scale-exit {
+    opacity: 1;
+    transform: scale(1);
+  }
+
+  .scale-exit-active {
+    opacity: 0;
+    transform: scale(0);
+    transition: opacity ${scaleTransitionTime}ms ease, transform ${scaleTransitionTime}ms cubic-bezier(1, 0.5, 0.8, 1);
+  }
+`;
+
+const amountToNumber = (amount: string) => {
+  const parsedAmount = amount.replace(/[%,$ ]/g, '');
+  return parseInt(parsedAmount);
+};
+
+export interface TxDropdownProps {
+  headerText?: string;
+  inputText?: string;
+  inputError?: boolean;
+  selectedType: { id: string; label: string; value: string };
+  onSelectedTypeChange?: (newRepayType: { id: string; label: string; value: string }) => void;
+  typeOptions?: { id: string; label: string; value: string }[];
+  readOnly?: boolean;
+  loading?: boolean;
+  loadingText?: string;
+  displayGuidance?: boolean;
+}
+
+export const TxDropdown: FC<TxDropdownProps> = ({
+  headerText,
+  inputText,
+  inputError,
+  selectedType,
+  onSelectedTypeChange,
+  typeOptions,
+  readOnly,
+  loading,
+  loadingText,
+  displayGuidance,
+  children,
+  ...props
+}) => {
+  const { t } = useAppTranslation('common');
+
+  let listItems: SearchListItem[] = [];
+  let zappableItems: SearchListItem[] = [];
+  let selectedItem: SearchListItem = {
+    id: selectedType?.id || '',
+    // icon: selectedCredit?.icon,
+    label: selectedType?.label,
+    value: selectedType?.value,
+  };
+
+  if (typeOptions && typeOptions.length > 1) {
+    listItems = typeOptions
+      .filter((s) => !!s)
+      .map((item) => {
+        return {
+          id: item!.id,
+          // icon: '',
+          label: item!.label,
+          value: item?.value,
+        };
+      });
+  }
+
+  const openSearchList = () => {
+    setOpenedSearch(true);
+  };
+
+  const [openedSearch, setOpenedSearch] = useState(false);
+  const searchListHeader = readOnly
+    ? t('components.transaction.deposit-and-repay.select-repay')
+    : t('components.transaction.deposit-and-repay.select-repay');
+
+  return (
+    <StyledTxCreditLineInput {...props}>
+      <>{headerText && <Header>{headerText}</Header>}</>
+      {!readOnly && openedSearch && (
+        <CSSTransition in={openedSearch} appear={true} timeout={scaleTransitionTime} classNames="scale">
+          <StyledSearchList
+            list={listItems}
+            headerText={searchListHeader}
+            selected={selectedItem}
+            //@ts-ignore
+            setSelected={(item) => (onSelectedTypeChange ? onSelectedTypeChange(item) : undefined)}
+            onCloseList={() => setOpenedSearch(false)}
+          />
+        </CSSTransition>
+      )}
+
+      {/* NOTE Using fragments here because: https://github.com/yearn/yearn-finance-v3/pull/565 */}
+      <>
+        <CreditLineInfo center={false} onClick={openSearchList}>
+          <CreditLineSelector onClick={listItems?.length > 1 ? openSearchList : undefined} center={false}>
+            <CreditLineIconContainer onClick={openSearchList}>
+              <StyledIcon Component={WalletIcon} />
+              {listItems?.length > 1 && <CreditLineListIcon Component={ZapIcon} />}
+            </CreditLineIconContainer>
+            <CreditLineName>{selectedItem.value}</CreditLineName>
+          </CreditLineSelector>
+          <CreditLineData>
+            <LineTitle ellipsis> Repay From: {selectedType.value} </LineTitle>
+          </CreditLineData>
+        </CreditLineInfo>
+      </>
+    </StyledTxCreditLineInput>
+  );
+};

--- a/src/core/store/modules/lines/lines.actions.ts
+++ b/src/core/store/modules/lines/lines.actions.ts
@@ -363,6 +363,7 @@ const claimAndRepay = createAsyncThunk<
     lineAddress: Address;
     claimToken: Address;
     calldata: BytesLike;
+    network: Network;
   },
   ThunkAPI
 >(
@@ -698,6 +699,7 @@ export const LinesActions = {
   approveDeposit,
   addCredit,
   depositAndRepay,
+  depositAndClose,
   borrowCredit,
   deploySecuredLine,
   // approveZapOut,


### PR DESCRIPTION
## Description

Adding a dropdown input to switch between Repayment Types

## Related Issue

[Update Modals Epic](https://www.notion.so/Update-modals-038a058a39784393b1aa55b2beaf7373#1f7153c50d0d48ba943c6a79cac788d6)

## Motivation and Context

Allowing users to choose how to repay 

## How Has This Been Tested?

Manual

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/69639595/200842950-6761f360-85d4-4d17-a430-e7962b49b2a9.png)

![image](https://user-images.githubusercontent.com/69639595/200842926-08be9a85-5426-4d4a-b6c1-f814e24e3445.png)

![image](https://user-images.githubusercontent.com/69639595/200842766-6ee0ee8c-4b65-4ef2-9054-aff1388c32a4.png)

![image](https://user-images.githubusercontent.com/69639595/200843003-fc65d1e6-af79-4a91-a66f-003794d21ea1.png)
