### PR TITLE
add deployLineWithConfig to store, toggle button to switch methods

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -180,7 +180,11 @@
         "header": "Deploy Credit Line",
         "select-borrower": "1. Select a borrower for the line",
         "select-ttl": "2. Select a deadline for the line",
-        "time-to-live": "Time this line will remain active for (in days):"
+        "time-to-live": "Time this line will remain active for (in days):",
+        "cratio": "3. Select a Collateralization Ratio for",
+        "cratio-input": "Your Cratio",
+        "revenue-split": "4. Select a Revenue Split Ratio for",
+        "revenue-split-input": "Your revenue split"
       },
       "borrow-credit": {
         "header": "Borrow",

--- a/src/client/components/app/LineDetailsDisplay/CreditEventsTable.tsx
+++ b/src/client/components/app/LineDetailsDisplay/CreditEventsTable.tsx
@@ -260,8 +260,8 @@ export const CreditEventsTable = (props: CreditEventsTableProps) => {
             filterLabel="Show 0% APY"
             //@ts-ignore
             filterBy={''}
-            //@ts-ignore
-            onAction={console.log('o')}
+            initialSortBy="deposit"
+            onAction={() => console.log('action')}
             wrap
           />
         </ViewContainer>

--- a/src/client/components/app/Transactions/DeployLineTx.tsx
+++ b/src/client/components/app/Transactions/DeployLineTx.tsx
@@ -7,6 +7,8 @@ import { useAppTranslation, useAppDispatch, useAppSelector } from '@hooks';
 import { LinesActions, WalletSelectors } from '@store';
 import { getConstants } from '@src/config/constants';
 
+import { ToggleButton } from '../../common';
+
 import { TxContainer } from './components/TxContainer';
 import { TxAddressInput } from './components/TxAddressInput';
 import { TxTTLInput } from './components/TxTTLInput';
@@ -17,6 +19,13 @@ import { TxStatus } from './components/TxStatus';
 const StyledTransaction = styled(TxContainer)``;
 
 const { LineFactory_GOERLI } = getConstants();
+
+const SectionContent = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  grid-gap: 1.2rem;
+  justify-content: right;
+`;
 
 interface DeployLineProps {
   header: string;
@@ -151,6 +160,21 @@ export const DeployLineTx: FC<DeployLineProps> = (props) => {
         ttlType={true}
       />
       {inputTTLWarning !== '' ? <div style={{ color: '#C3272B' }}>{inputTTLWarning}</div> : ''}
+      <SectionContent>
+        <>
+          Advanced Mode
+          <ToggleButton
+            selected={false}
+            setSelected={() => {}}
+            className=""
+            disabled={false}
+            color=""
+            onClick={() => {}}
+            ariaLabel=""
+          />
+        </>
+      </SectionContent>
+
       <TxActions>
         <TxActionButton
           key={''}

--- a/src/client/components/app/Transactions/DeployLineTx.tsx
+++ b/src/client/components/app/Transactions/DeployLineTx.tsx
@@ -141,7 +141,10 @@ export const DeployLineTx: FC<DeployLineProps> = (props) => {
       return;
     }
 
+    // BPS IS USED so we must multiply by 10^2
     let BNCratio = toWei(cratio, 2);
+
+    // BPS IS NOT USED so we run through toWei to get BN
     let BNRevenueSplit = toWei(revenueSplit, 0);
     console.log(typeof BNCratio);
 

--- a/src/client/components/app/Transactions/DeployLineTx.tsx
+++ b/src/client/components/app/Transactions/DeployLineTx.tsx
@@ -42,6 +42,8 @@ interface DeployLineProps {
 export const DeployLineTx: FC<DeployLineProps> = (props) => {
   const { t } = useAppTranslation('common');
   const dispatch = useAppDispatch();
+
+  // Deploy Line base data state
   const walletNetwork = useAppSelector(WalletSelectors.selectWalletNetwork);
   const [transactionCompleted, setTransactionCompleted] = useState(0);
   const { header, onClose } = props;
@@ -50,6 +52,15 @@ export const DeployLineTx: FC<DeployLineProps> = (props) => {
   const [inputTTLWarning, setTTLWarning] = useState('');
   const [loading, setLoading] = useState(false);
   const [timeToLive, setTimeToLive] = useState('0');
+
+  // Deploy Line with config state
+  const [advancedMode, setAdvancedMode] = useState(false);
+  const [cratio, setCratio] = useState('0');
+  const [revenueSplit, setRevenueSplit] = useState('0');
+
+  const toggleSecuredMode = () => {
+    setAdvancedMode(!advancedMode);
+  };
 
   const onAmountChange = (ttl: string) => {
     let timeToLive = +ttl * 24 * 60 * 60;
@@ -160,12 +171,17 @@ export const DeployLineTx: FC<DeployLineProps> = (props) => {
         ttlType={true}
       />
       {inputTTLWarning !== '' ? <div style={{ color: '#C3272B' }}>{inputTTLWarning}</div> : ''}
+      {advancedMode ? (
+        <h3>advanced Mode something here and something there</h3>
+      ) : (
+        <h4>Not advanced Mode something here and something there</h4>
+      )}
       <SectionContent>
         <>
           Advanced Mode
           <ToggleButton
-            selected={false}
-            setSelected={() => {}}
+            selected={advancedMode}
+            setSelected={() => toggleSecuredMode()}
             className=""
             disabled={false}
             color=""

--- a/src/client/components/app/Transactions/components/TxNumberInput.tsx
+++ b/src/client/components/app/Transactions/components/TxNumberInput.tsx
@@ -161,7 +161,7 @@ export const TxNumberInput: FC<TxNumberInputProps> = ({
           <PositionData>
             <AmountInputContainer>
               <RatesContainer>
-                {headerText && <AmountTitle ellipsis>{headerText}</AmountTitle>}
+                {inputLabel && <AmountTitle ellipsis>{inputLabel}</AmountTitle>}
                 <InterestRateInputContainer>
                   <StyledAmountInput
                     value={amount}

--- a/src/core/services/LineFactoryService.ts
+++ b/src/core/services/LineFactoryService.ts
@@ -94,23 +94,31 @@ export class LineFactoryServiceImpl {
     );
   }
 
-  public async deploySecuredLineWtihConfig(
-    contractAddress: Address,
-    oracle: string,
-    arbiter: string,
-    borrower: string,
-    ttl: BigNumber,
-    revenueSplit: BigNumber,
-    cratio: BigNumber,
-    swapTarget: string,
-    dryRun: boolean
-  ): Promise<TransactionResponse | PopulatedTransaction> {
+  public async deploySecuredLineWtihConfig(props: {
+    borrower: string;
+    ttl: number;
+    network: Network;
+    cratio: number;
+    revenueSplit: number;
+  }): Promise<TransactionResponse | PopulatedTransaction> {
+    const { borrower, ttl, cratio, revenueSplit, network } = props;
+    const data = {
+      borrower,
+      ttl,
+      cratio,
+      revenueSplit,
+      network,
+      arbiter: Arbiter_GOERLI,
+      oracle: KibaSero_oracle,
+      factoryAddress: LineFactory_GOERLI,
+      swapTarget: SwapTarget_GOERLI,
+    };
     return await this.executeContractMethod(
-      contractAddress,
+      data.factoryAddress,
       'deploySecuredLineWithConfig',
-      [oracle, arbiter, borrower, ttl, revenueSplit, cratio, swapTarget],
-      'goerli',
-      dryRun
+      [data.oracle, data.arbiter, data.borrower, data.ttl, data.revenueSplit, data.cratio, data.swapTarget],
+      data.network,
+      false
     );
   }
 

--- a/src/core/store/modules/lines/lines.actions.ts
+++ b/src/core/store/modules/lines/lines.actions.ts
@@ -223,6 +223,9 @@ const deploySecuredLineWithConfig = createAsyncThunk<void, DeploySecuredLineWith
     const deploySecuredLineWithConfigData = await lineFactoryService.deploySecuredLineWtihConfig({
       ...deployData,
     });
+
+    console.log('new secured line with Config deployed. tx response', deploySecuredLineWithConfigData);
+    // await dispatch(getLine(deployedLineData.))
   }
 );
 

--- a/src/core/store/modules/lines/lines.actions.ts
+++ b/src/core/store/modules/lines/lines.actions.ts
@@ -19,6 +19,7 @@ import {
   BorrowCreditProps,
   Network,
   DeploySecuredLineProps,
+  DeploySecuredLineWithConfigProps,
 } from '@types';
 import {
   toBN,
@@ -212,6 +213,16 @@ const deploySecuredLine = createAsyncThunk<void, DeploySecuredLineProps, ThunkAP
 
     console.log('new secured line deployed. tx response', deployedLineData);
     // await dispatch(getLine(deployedLineData.))
+  }
+);
+
+const deploySecuredLineWithConfig = createAsyncThunk<void, DeploySecuredLineWithConfigProps, ThunkAPI>(
+  'lines/deploySecuredLineWithConfigProps',
+  async (deployData, { getState, extra }) => {
+    const { lineFactoryService } = extra.services;
+    const deploySecuredLineWithConfigData = await lineFactoryService.deploySecuredLineWtihConfig({
+      ...deployData,
+    });
   }
 );
 
@@ -708,6 +719,7 @@ export const LinesActions = {
   depositAndClose,
   borrowCredit,
   deploySecuredLine,
+  deploySecuredLineWithConfig,
   // approveZapOut,
   // signZapOut,
   withdrawLine,


### PR DESCRIPTION
## Description

Add an advanced mode (deployLineWithConfig) 

## Related Issue

[DeployLineWithConfig](https://www.notion.so/DeployLineWithConfig-f8518a47e1264accb93e22bda116e4bb)

## Motivation and Context

Allows devs to test different transactions without need for collateral

## How Has This Been Tested?

Manual testing

## Screenshots (if appropriate):

Advanced mode off: 
![image](https://user-images.githubusercontent.com/69639595/201707199-a2dbbe14-1465-45a2-aed0-797d20a7f29f.png)

Advanced mode on: 
![image](https://user-images.githubusercontent.com/69639595/201707277-3dab85ea-b46a-4712-960c-dc2245fe812b.png)
