### PR TITLE
Frontend Cleanup and Bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "bnc-onboard": "1.38.2",
     "craco-alias": "3.0.1",
     "cross-env": "7.0.3",
+    "date-fns": "^2.29.3",
     "eslint-config-prettier": "8.5.0",
     "eslint-plugin-prettier": "4.0.0",
     "ethers": "5.4.5",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -58,8 +58,9 @@
       "total-debt": "Outstanding Debt",
       "total-credit": "Total Credit",
       "collateral": "Collateral",
-      "start": "Start Time",
-      "end": "End Time",
+      "start": "Origination",
+      "end": "Maturity",
+      "time-to-live": "Days To Maturity",
       "line": "Line Id",
       "revenue": "Spigoted Revenue"
     },

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -186,6 +186,10 @@
           "enable-cta": "Enable token"
         }
       },
+      "deposit-collateral": {
+        "header": "Deposit Collateral",
+        "select-token": "The Token Used As Collateral"
+      },
       "arbiter-liquidate": {
         "header": "Liquidate Borrowers",
         "select-credit": "1. Select a borrower to liquidate",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -197,9 +197,9 @@
         "select-ttl": "2. Insert a deadline for the line",
         "time-to-live": "Time this line will remain active for (in days):",
         "cratio": "3. Select a Collateralization Ratio",
-        "cratio-input": "Your Cratio",
+        "cratio-input": "Collaterization Ratio",
         "revenue-split": "4. Select a Revenue Split",
-        "revenue-split-input": "Your revenue split"
+        "revenue-split-input": "Revenue Split"
       },
       "borrow-credit": {
         "header": "Borrow",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -17,13 +17,13 @@
     "positions-card": {
       "line": "Line",
       "positions": "Positions",
-      "drate": "dRate",
-      "frate": "fRate",
+      "drate": "Draw Down Rate",
+      "frate": "Facility Rate",
       "total-deposits": "Supplied",
       "token": "Token",
       "status": "Status",
       "principal": "Borrowed",
-      "interest": "Interest",
+      "interest": "Interest Accrued",
       "lender": "Lender"
     },
     "list-card": {

--- a/public/locales/en/lineDetails.json
+++ b/public/locales/en/lineDetails.json
@@ -9,6 +9,8 @@
     "totalInterestPaid": "Lifetime Interest Paid",
     "secured-by": "Secured By ",
     "unsecured": "This is an unsecured line of credit. You MUST trust the borrower.",
+    "start": "Origination",
+    "end": "Maturity",
     "revenue": {
       "title": "Revenue",
       "per-month": "/ month",

--- a/src/client/components/app/DetailCard/index.tsx
+++ b/src/client/components/app/DetailCard/index.tsx
@@ -85,6 +85,7 @@ const StyledCardHeader = styled(CardHeader)`
 const StyledCard = styled(Card)`
   padding: ${({ theme }) => theme.card.padding} 0;
   width: 100%;
+  ${({ theme }) => theme.colors.background};
 `;
 
 const SectionContent = styled.div`

--- a/src/client/components/app/LineDetailsDisplay/LineMetadata.tsx
+++ b/src/client/components/app/LineDetailsDisplay/LineMetadata.tsx
@@ -88,7 +88,6 @@ const AssetsListCard = styled(DetailCard)`
     }
   }
 ` as typeof DetailCard;
-
 interface LineMetadataProps {
   principal: string;
   deposit: string;
@@ -288,8 +287,9 @@ export const LineMetadata = (props: LineMetadataProps) => {
       </ThreeColumnLayout>
 
       <ViewContainer>
+        <SectionHeader>{t('lineDetails:metadata.escrow.assets-list.title')}</SectionHeader>
         <AssetsListCard
-          header={t('lineDetails:metadata.escrow.assets-list.title')}
+          header={' '} //{t('lineDetails:metadata.escrow.assets-list.title')}
           data-testid="line-assets-list"
           metadata={[
             {

--- a/src/client/components/app/LineDetailsDisplay/LineMetadata.tsx
+++ b/src/client/components/app/LineDetailsDisplay/LineMetadata.tsx
@@ -1,6 +1,7 @@
 import { isEmpty } from 'lodash';
 import { BigNumber } from 'ethers';
 import styled from 'styled-components';
+import { format } from 'date-fns';
 
 import { device } from '@themes/default';
 import { useAppDispatch, useAppSelector, useAppTranslation } from '@hooks';
@@ -137,7 +138,7 @@ export const LineMetadata = (props: LineMetadataProps) => {
   const { NETWORK } = getEnv();
   const connectWallet = () => dispatch(WalletActions.walletSelect({ network: NETWORK }));
 
-  const { principal, deposit, totalInterestPaid, revenue, deposits } = props;
+  const { principal, deposit, totalInterestPaid, revenue, deposits, startTime, endTime } = props;
   const modules = [revenue && 'revenue', deposits && 'escrow'].filter((x) => !!x);
   const totalRevenue = isEmpty(revenue)
     ? ''
@@ -264,6 +265,8 @@ export const LineMetadata = (props: LineMetadataProps) => {
     }
   };
 
+  const startDateHumanized = format(new Date(startTime * 1000), 'MMMM dd, yyyy');
+  const endDateHumanized = format(new Date(endTime * 1000), 'MMMM dd, yyyy');
   return (
     <>
       <ThreeColumnLayout>
@@ -273,6 +276,8 @@ export const LineMetadata = (props: LineMetadataProps) => {
           title={t('lineDetails:metadata.totalInterestPaid')}
           data={`$ ${prettyNumbers(totalInterestPaid)}`}
         />
+        <MetricDataDisplay title={t('lineDetails:metadata.start')} data={startDateHumanized} />
+        <MetricDataDisplay title={t('lineDetails:metadata.end')} data={endDateHumanized} />
       </ThreeColumnLayout>
       <SectionHeader>
         {t('lineDetails:metadata.secured-by')}

--- a/src/client/components/app/LineDetailsDisplay/PositionsTable.tsx
+++ b/src/client/components/app/LineDetailsDisplay/PositionsTable.tsx
@@ -198,7 +198,7 @@ export const PositionsTable = ({ positions, displayLine = false }: PositionsProp
 
     //If user is lender, and line has amount to withdraw, return withdraw action
     if (
-      getAddress(position.lender) == userWallet &&
+      getAddress(position.lender) === userWallet &&
       BigNumber.from(position.deposit).gt(BigNumber.from(position.principal))
     ) {
       return [
@@ -235,7 +235,7 @@ export const PositionsTable = ({ positions, displayLine = false }: PositionsProp
               hide: !displayLine,
               header: t('components.positions-card.line'),
               sortable: true,
-              width: '8rem',
+              width: '13rem',
               className: 'col-apy',
             },
             {
@@ -256,14 +256,14 @@ export const PositionsTable = ({ positions, displayLine = false }: PositionsProp
               key: 'deposit',
               header: t('components.positions-card.total-deposits'),
               sortable: true,
-              width: '10rem',
+              width: '13rem',
               className: 'col-assets',
             },
             {
               key: 'principal',
               header: t('components.positions-card.principal'),
               sortable: true,
-              width: '10rem',
+              width: '13rem',
               className: 'col-assets',
             },
             {
@@ -277,14 +277,14 @@ export const PositionsTable = ({ positions, displayLine = false }: PositionsProp
               key: 'drate',
               header: t('components.positions-card.drate'),
               sortable: true,
-              width: '7rem',
+              width: '10rem',
               className: 'col-assets',
             },
             {
               key: 'frate',
               header: t('components.positions-card.frate'),
               sortable: true,
-              width: '7rem',
+              width: '10rem',
               className: 'col-assets',
             },
             {
@@ -301,7 +301,7 @@ export const PositionsTable = ({ positions, displayLine = false }: PositionsProp
             frate: `${normalizeAmount(position.fRate, 2)} %`,
             line: (
               <RouterLink to={`/lines/${currentNetwork}/${position.line}`} key={position.line} selected={false}>
-                {position.line}
+                {formatAddress(position.line)}
                 <RedirectLinkIcon />
               </RouterLink>
             ),
@@ -325,20 +325,21 @@ export const PositionsTable = ({ positions, displayLine = false }: PositionsProp
             ),
             actions: <ActionButtons value={position.id} actions={getUserPositionActions(position)} />,
           }))}
-          SearchBar={
-            <>
-              <Input
-                value={''}
-                onChange={(e) => console.log(e)}
-                placeholder={t('components.search-input.search')}
-                Icon={SearchIcon}
-              />
+          // TODO: Add search bar back when there is a need for it.
+          // SearchBar={
+          //   <>
+          //     <Input
+          //       value={''}
+          //       onChange={(e) => console.log(e)}
+          //       placeholder={t('components.search-input.search')}
+          //       Icon={SearchIcon}
+          //     />
 
-              {userRoleMetadata.role === LENDER_POSITION_ROLE && (
-                <Button onClick={depositHandler}>{ctaButtonText}</Button>
-              )}
-            </>
-          }
+          //     {userRoleMetadata.role === LENDER_POSITION_ROLE && (
+          //       <Button onClick={depositHandler}>{ctaButtonText}</Button>
+          //     )}
+          //   </>
+          // }
           searching={false}
           filterLabel="Show 0% APY"
           initialSortBy="deposit"

--- a/src/client/components/app/LineDetailsDisplay/PositionsTable.tsx
+++ b/src/client/components/app/LineDetailsDisplay/PositionsTable.tsx
@@ -17,9 +17,8 @@ import { device } from '@themes/default';
 import { DetailCard, ActionButtons, ViewContainer } from '@components/app';
 import { Input, SearchIcon, Button, RedirectIcon, Link } from '@components/common';
 import { ARBITER_POSITION_ROLE, BORROWER_POSITION_ROLE, LENDER_POSITION_ROLE, CreditPosition } from '@src/core/types';
-import { humanize, formatAddress, normalizeAmount } from '@src/utils';
+import { humanize, formatAddress, normalizeAmount, getENS } from '@src/utils';
 import { getEnv } from '@config/env';
-import { getENS } from '@src/utils';
 
 const PositionsCard = styled(DetailCard)`
   max-width: ${({ theme }) => theme.globalMaxWidth};

--- a/src/client/components/app/LineDetailsDisplay/PositionsTable.tsx
+++ b/src/client/components/app/LineDetailsDisplay/PositionsTable.tsx
@@ -145,7 +145,6 @@ export const PositionsTable = ({ positions, displayLine = false }: PositionsProp
 
   const borrowHandler = (position?: string) => {
     if (!position) return;
-    console.log('borrow', position);
     dispatch(LinesActions.setSelectedLinePosition({ position }));
     dispatch(ModalsActions.openModal({ modalName: 'borrow' }));
   };

--- a/src/client/components/app/LineDetailsDisplay/PositionsTable.tsx
+++ b/src/client/components/app/LineDetailsDisplay/PositionsTable.tsx
@@ -138,6 +138,8 @@ export const PositionsTable = ({ positions, displayLine = false }: PositionsProp
   };
 
   const withdrawHandler = (position?: string) => {
+    console.log('withdraw handler position: ', position);
+    console.log('withdraw handler selectedLine: ', selectedLine);
     if (!position) return;
     dispatch(LinesActions.setSelectedLinePosition({ position }));
     dispatch(ModalsActions.openModal({ modalName: 'withdraw' }));

--- a/src/client/components/app/LineDetailsDisplay/PositionsTable.tsx
+++ b/src/client/components/app/LineDetailsDisplay/PositionsTable.tsx
@@ -220,7 +220,7 @@ export const PositionsTable = ({ positions, displayLine = false }: PositionsProp
       <TableHeader>{t('components.positions-card.positions')}</TableHeader>
       <ViewContainer>
         <PositionsCard
-          header={t('components.positions-card.positions')}
+          header={''} //{t('components.positions-card.positions')}
           data-testid="vaults-opportunities-list"
           metadata={[
             {
@@ -249,7 +249,7 @@ export const PositionsTable = ({ positions, displayLine = false }: PositionsProp
               key: 'token',
               header: t('components.positions-card.token'),
               sortable: true,
-              width: '10rem',
+              width: '8rem',
               className: 'col-available',
             },
             {
@@ -270,7 +270,7 @@ export const PositionsTable = ({ positions, displayLine = false }: PositionsProp
               key: 'interest',
               header: t('components.positions-card.interest'),
               sortable: true,
-              width: '10rem',
+              width: '8rem',
               className: 'col-assets',
             },
             {

--- a/src/client/components/app/LineDetailsDisplay/PositionsTable.tsx
+++ b/src/client/components/app/LineDetailsDisplay/PositionsTable.tsx
@@ -327,20 +327,20 @@ export const PositionsTable = ({ positions, displayLine = false }: PositionsProp
             actions: <ActionButtons value={position.id} actions={getUserPositionActions(position)} />,
           }))}
           // TODO: Add search bar back when there is a need for it.
-          // SearchBar={
-          //   <>
-          //     <Input
-          //       value={''}
-          //       onChange={(e) => console.log(e)}
-          //       placeholder={t('components.search-input.search')}
-          //       Icon={SearchIcon}
-          //     />
+          SearchBar={
+            <>
+              {/* <Input
+                value={''}
+                onChange={(e) => console.log(e)}
+                placeholder={t('components.search-input.search')}
+                Icon={SearchIcon}
+              /> */}
 
-          //     {userRoleMetadata.role === LENDER_POSITION_ROLE && (
-          //       <Button onClick={depositHandler}>{ctaButtonText}</Button>
-          //     )}
-          //   </>
-          // }
+              {userRoleMetadata.role === LENDER_POSITION_ROLE && (
+                <Button onClick={depositHandler}>{ctaButtonText}</Button>
+              )}
+            </>
+          }
           searching={false}
           filterLabel="Show 0% APY"
           initialSortBy="deposit"

--- a/src/client/components/app/RecommendationsCard/index.tsx
+++ b/src/client/components/app/RecommendationsCard/index.tsx
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { format, differenceInDays } from 'date-fns';
 
 import { prettyNumbers, formatAddress, unnullify } from '@utils';
 import { Card, CardHeader, CardContent, Text, Icon, ChevronRightIcon } from '@components/common';
@@ -111,6 +112,7 @@ const Metric = styled.span`
 
 const MetricsText = styled.span`
   font-size: 1.6rem;
+  font-weight: normal;
 `;
 
 interface RecommendationsProps {
@@ -126,53 +128,78 @@ export const RecommendationsCard = ({ header, subHeader, items, ...props }: Reco
     return null;
   }
   // todo handle loading of principal/deposit vals with spinner or something
+  console.log('Recommendations card items: ', items);
   return (
     <ContainerCard {...props}>
       <CardHeader header={header} subHeader={subHeader} />
 
       <StyledCardContent>
-        {items.map((item, i) => (
-          <ItemCard key={`${i}-${item.borrower}`} variant="primary" onClick={item.onAction ? item.onAction : undefined}>
-            {item.header && <ItemHeader>{item.header}</ItemHeader>}
+        {items.map((item, i) => {
+          const startDate = new Date(item.start * 1000);
+          const endDate = new Date(item.end * 1000);
+          const startDateHumanized = format(startDate, 'MMMM dd, yyyy');
+          const endDateHumanized = format(endDate, 'MMMM dd, yyyy');
+          const daysDiff = differenceInDays(endDate, startDate);
+          const timeToLive = daysDiff === 1 ? `${daysDiff} day` : `${daysDiff} days`;
+          return (
+            <ItemCard
+              key={`${i}-${item.borrower}`}
+              variant="primary"
+              onClick={item.onAction ? item.onAction : undefined}
+            >
+              {item.header && <ItemHeader>{item.header}</ItemHeader>}
 
-            <TopIcon>
-              <TokenIcon symbol={''} icon={item.icon} size="xxBig" />
-            </TopIcon>
+              <TopIcon>
+                <TokenIcon symbol={''} icon={item.icon} size="xxBig" />
+              </TopIcon>
 
-            <ItemInfo>
-              <ItemName>
-                {' '}
-                {t('components.line-card.borrower')}: {formatAddress(getENS(item.borrower, ensMap)!)}
-              </ItemName>
-              <Divider />
-              <Metric>
-                ${prettyNumbers(unnullify('0'))} / $ {/*TODO: Need to add this functionality*/}
-                {prettyNumbers(item.deposit)}
-              </Metric>
-              <MetricsTextContainer>
-                <MetricsText>
+              <ItemInfo>
+                <ItemName>
                   {' '}
-                  {t('components.line-card.total-debt')} / {t('components.line-card.total-credit')}{' '}
-                </MetricsText>
-              </MetricsTextContainer>
-              <Divider />
+                  {t('components.line-card.borrower')}: {formatAddress(getENS(item.borrower, ensMap)!)}
+                </ItemName>
+                <Divider />
 
-              <ItemInfoLabel>{t('components.line-card.secured-by')}:</ItemInfoLabel>
-              <Metric>
-                ${prettyNumbers(unnullify(item?.escrow?.collateralValue))} / ${' '}
-                {/*TODO: Need to add this functionality*/}
-                {prettyNumbers(unnullify('0'))}
-              </Metric>
-              <MetricsTextContainer>
-                <MetricsText>
-                  {' '}
-                  {t('components.line-card.collateral')} / {t('components.line-card.revenue')}{' '}
-                </MetricsText>
-              </MetricsTextContainer>
-            </ItemInfo>
-            {item.onAction && <TokenListIcon Component={ChevronRightIcon} />}
-          </ItemCard>
-        ))}
+                <Metric>
+                  ${prettyNumbers(unnullify('0'))} / $ {/*TODO: Need to add this functionality*/}
+                  {prettyNumbers(item.deposit)}
+                </Metric>
+                <MetricsTextContainer>
+                  <MetricsText>
+                    {' '}
+                    {t('components.line-card.total-debt')} / {t('components.line-card.total-credit')}{' '}
+                  </MetricsText>
+                </MetricsTextContainer>
+                <Divider />
+
+                <ItemInfoLabel>{t('components.line-card.secured-by')}:</ItemInfoLabel>
+                <Metric>
+                  ${prettyNumbers(unnullify(item?.escrow?.collateralValue))} / ${' '}
+                  {/*TODO: Need to add this functionality*/}
+                  {prettyNumbers(unnullify('0'))}
+                </Metric>
+                <MetricsTextContainer>
+                  <MetricsText>
+                    {' '}
+                    {t('components.line-card.collateral')} / {t('components.line-card.revenue')}{' '}
+                  </MetricsText>
+                </MetricsTextContainer>
+                <Divider />
+
+                <ItemInfoLabel>
+                  <span>
+                    {t('components.line-card.start')}: <MetricsText>{startDateHumanized}</MetricsText>
+                  </span>
+                </ItemInfoLabel>
+                <ItemInfoLabel>
+                  {t('components.line-card.end')}: <MetricsText>{endDateHumanized}</MetricsText>
+                </ItemInfoLabel>
+                <Divider />
+              </ItemInfo>
+              {item.onAction && <TokenListIcon Component={ChevronRightIcon} />}
+            </ItemCard>
+          );
+        })}
       </StyledCardContent>
     </ContainerCard>
   );

--- a/src/client/components/app/Transactions/AddCollateralTx.tsx
+++ b/src/client/components/app/Transactions/AddCollateralTx.tsx
@@ -306,10 +306,10 @@ export const AddCollateralTx: FC<AddCollateralTxProps> = (props) => {
   }
 
   return (
-    <StyledTransaction onClose={onClose} header={header || t('components.transaction.title')}>
+    <StyledTransaction onClose={onClose} header={t('components.transaction.deposit-collateral.header')}>
       <TxTokenInput
         key={'token-input'}
-        headerText={t('components.transaction.add-credit.select-token')}
+        headerText={t('components.transaction.deposit-collateral.select-token')}
         inputText={tokenHeaderText}
         amount={targetTokenAmount}
         amountValue={String(10000000 * Number(targetTokenAmount))}

--- a/src/client/components/app/Transactions/AddCreditPositionTx.tsx
+++ b/src/client/components/app/Transactions/AddCreditPositionTx.tsx
@@ -89,8 +89,8 @@ export const AddCreditPositionTx: FC<AddCreditPositionProps> = (props) => {
   const [transactionApproved, setTransactionApproved] = useState(true);
   const [transactionLoading, setLoading] = useState(false);
   const [targetTokenAmount, setTargetTokenAmount] = useState('0');
-  const [drate, setDrate] = useState('0');
-  const [frate, setFrate] = useState('0');
+  const [drate, setDrate] = useState('');
+  const [frate, setFrate] = useState('');
   const [lenderAddress, setLenderAddress] = useState(walletAddress ? walletAddress : '');
   const [selectedTokenAddress, setSelectedTokenAddress] = useState('');
   const [transactionType, setTransactionType] = useState('propose');

--- a/src/client/components/app/Transactions/AddCreditPositionTx.tsx
+++ b/src/client/components/app/Transactions/AddCreditPositionTx.tsx
@@ -359,7 +359,7 @@ export const AddCreditPositionTx: FC<AddCreditPositionProps> = (props) => {
         maxAmount={acceptingOffer ? targetTokenAmount : targetBalance}
         selectedToken={positionToken}
         onSelectedTokenChange={onSelectedSellTokenChange}
-        tokenOptions={sourceAssetOptions}
+        tokenOptions={acceptingOffer ? [] : sourceAssetOptions}
         readOnly={acceptingOffer}
       />
 

--- a/src/client/components/app/Transactions/BorrowCreditTx.tsx
+++ b/src/client/components/app/Transactions/BorrowCreditTx.tsx
@@ -41,7 +41,8 @@ export const BorrowCreditTx: FC<BorrowCreditProps> = (props) => {
   const selectedCredit = useAppSelector(LinesSelectors.selectSelectedLine);
   const positions = useAppSelector(LinesSelectors.selectPositionsForSelectedLine);
 
-  console.log('positions', positions);
+  console.log('Borrow Credit Tx selectedCredit', selectedCredit);
+  console.log('Borrow Credit Tx selectedPosition', selectedPosition);
 
   const _updatePosition = () =>
     onPositionChange({

--- a/src/client/components/app/Transactions/DeployLineTx.tsx
+++ b/src/client/components/app/Transactions/DeployLineTx.tsx
@@ -204,8 +204,7 @@ export const DeployLineTx: FC<DeployLineProps> = (props) => {
       <TxAddressInput
         key={'credit-input'}
         headerText={t('components.transaction.deploy-line.select-borrower')}
-        // inputText={t('components.transaction.deploy-line.select-borrower')}
-        inputText={''}
+        inputText={'Borrower Address'}
         onAddressChange={onBorrowerAddressChange}
         address={borrowerAddress}
         // creditOptions={sourceCreditOptions}

--- a/src/client/components/app/Transactions/DeployLineTx.tsx
+++ b/src/client/components/app/Transactions/DeployLineTx.tsx
@@ -123,7 +123,7 @@ export const DeployLineTx: FC<DeployLineProps> = (props) => {
         })
       ).then((res) => {
         if (res.meta.requestStatus === 'rejected') {
-          setTransactionCompleted(2);
+          // setTransactionCompleted(2);
           setLoading(false);
         }
         if (res.meta.requestStatus === 'fulfilled') {
@@ -162,7 +162,7 @@ export const DeployLineTx: FC<DeployLineProps> = (props) => {
         })
       ).then((res) => {
         if (res.meta.requestStatus === 'rejected') {
-          setTransactionCompleted(2);
+          // setTransactionCompleted(2);
           setLoading(false);
         }
         if (res.meta.requestStatus === 'fulfilled') {

--- a/src/client/components/app/Transactions/RepayTx.tsx
+++ b/src/client/components/app/Transactions/RepayTx.tsx
@@ -41,7 +41,6 @@ export const DepositAndRepayTx: FC<DepositAndRepayProps> = (props) => {
   const [transactionLoading, setLoading] = useState(false);
   const [errors, setErrors] = useState<string[]>(['']);
   const [transactionApproved, setTransactionApproved] = useState(true);
-  const [targetAmount, setTargetAmount] = useState('1');
   const selectedCredit = useAppSelector(LinesSelectors.selectSelectedLine);
   const [selectedTokenAddress, setSelectedTokenAddress] = useState('');
   const walletNetwork = useAppSelector(WalletSelectors.selectWalletNetwork);
@@ -50,9 +49,19 @@ export const DepositAndRepayTx: FC<DepositAndRepayProps> = (props) => {
   const initialToken: string = selectedSellTokenAddress || DAI;
   const positions = useAppSelector(LinesSelectors.selectPositionsForSelectedLine);
 
-  console.log('Repay Modal - selected position: ', selectedPosition);
+  // Calculate maximum repay amount, then humanize for readability
+  const getMaxRepay = () => {
+    if (!selectedPosition) {
+      setErrors([...errors, 'no selected position']);
+      return;
+    }
+    let maxRepay: string = `${Number(selectedPosition.principal) + Number(selectedPosition.interestAccrued)}`;
+    maxRepay = normalize('amount', `${maxRepay}`, selectedPosition.token.decimals);
+    return maxRepay;
+  };
 
-  // setTargetAmount(String(Number(selectedPosition?.principal ?? '0') + Number(selectedPosition?.interestAccrued)));
+  // Set default repayment amounnt as the max repayment amount
+  const [targetAmount, setTargetAmount] = useState(getMaxRepay()!);
 
   const repaymentOptions = [
     { id: '1', label: 'Repay from:', value: 'Wallet' },
@@ -65,9 +74,6 @@ export const DepositAndRepayTx: FC<DepositAndRepayProps> = (props) => {
     selectedVaultOrLab: useAppSelector(VaultsSelectors.selectRecommendations)[0],
     allowTokenSelect: true,
   });
-
-  console.log('Repay Modal - Selected Sell Token Address: ', selectedSellTokenAddress);
-  console.log('Repay Modal - Selected Sell Token: ', selectedSellToken);
 
   useEffect(() => {
     console.log('repay type', repayType);
@@ -309,17 +315,6 @@ export const DepositAndRepayTx: FC<DepositAndRepayProps> = (props) => {
 
   const onSelectedSellTokenChange = (tokenAddress: string) => {
     dispatch(TokensActions.setSelectedTokenAddress({ tokenAddress }));
-  };
-
-  //Calculate maximum repay amount, then humanize for readability
-  const getMaxRepay = () => {
-    if (!selectedPosition) {
-      setErrors([...errors, 'no selected position']);
-      return;
-    }
-    let maxRepay: string = `${Number(selectedPosition.principal) + Number(selectedPosition.interestAccrued)}`;
-    maxRepay = normalize('amount', `${maxRepay}`, selectedPosition.token.decimals);
-    return maxRepay;
   };
 
   const targetBalance = normalizeAmount(selectedSellToken.balance, selectedSellToken.decimals);

--- a/src/client/components/app/Transactions/RepayTx.tsx
+++ b/src/client/components/app/Transactions/RepayTx.tsx
@@ -50,6 +50,10 @@ export const DepositAndRepayTx: FC<DepositAndRepayProps> = (props) => {
   const initialToken: string = selectedSellTokenAddress || DAI;
   const positions = useAppSelector(LinesSelectors.selectPositionsForSelectedLine);
 
+  console.log('Repay Modal - selected position: ', selectedPosition);
+
+  // setTargetAmount(String(Number(selectedPosition?.principal ?? '0') + Number(selectedPosition?.interestAccrued)));
+
   const repaymentOptions = [
     { id: '1', label: 'Repay from:', value: 'Wallet' },
     { id: '2', label: 'Repay from:', value: 'Claim' },
@@ -61,6 +65,9 @@ export const DepositAndRepayTx: FC<DepositAndRepayProps> = (props) => {
     selectedVaultOrLab: useAppSelector(VaultsSelectors.selectRecommendations)[0],
     allowTokenSelect: true,
   });
+
+  console.log('Repay Modal - Selected Sell Token Address: ', selectedSellTokenAddress);
+  console.log('Repay Modal - Selected Sell Token: ', selectedSellToken);
 
   useEffect(() => {
     console.log('repay type', repayType);
@@ -380,9 +387,9 @@ export const DepositAndRepayTx: FC<DepositAndRepayProps> = (props) => {
         amountValue={String(10000000 * Number(targetAmount))}
         maxAmount={getMaxRepay()}
         selectedToken={selectedSellToken}
-        onSelectedTokenChange={onSelectedSellTokenChange}
+        // onSelectedTokenChange={onSelectedSellTokenChange}
         // @cleanup TODO
-        tokenOptions={walletNetwork === 'goerli' ? testTokens : sourceAssetOptions}
+        // tokenOptions={walletNetwork === 'goerli' ? testTokens : sourceAssetOptions}
         // inputError={!!sourceStatus.error}
         readOnly={acceptingOffer}
         // displayGuidance={displaySourceGuidance}

--- a/src/client/components/app/Transactions/WithdrawCreditTx.tsx
+++ b/src/client/components/app/Transactions/WithdrawCreditTx.tsx
@@ -43,6 +43,8 @@ export const WithdrawCreditTx: FC<BorrowCreditProps> = (props) => {
   const setSelectedCredit = (lineAddress: string) => dispatch(LinesActions.setSelectedLineAddress({ lineAddress }));
   const positions = useAppSelector(LinesSelectors.selectPositionsForSelectedLine);
 
+  console.log('withdraw modal selectedCredit: ', selectedCredit);
+  console.log('withdraw modal selectedPosition: ', selectedPosition);
   //Calculate maximum withdraw amount, then humanize for readability
   const getMaxWithdraw = () => {
     if (!selectedPosition) {
@@ -154,7 +156,10 @@ export const WithdrawCreditTx: FC<BorrowCreditProps> = (props) => {
     },
   ];
 
-  if (!selectedCredit) return null;
+  if (!selectedCredit) {
+    console.log('withdraw modal selected credit is undefined: ', selectedCredit);
+    return null;
+  }
 
   if (transactionCompleted === 1) {
     return (

--- a/src/client/components/app/Transactions/components/TxCreditLineInput.tsx
+++ b/src/client/components/app/Transactions/components/TxCreditLineInput.tsx
@@ -6,8 +6,9 @@ import { TokenIcon } from '@components/app';
 import { useAppSelector, useAppTranslation } from '@hooks';
 import { Text, Icon, SearchList, LogoIcon, ZapIcon, SearchListItem, RedirectIcon, Link } from '@components/common';
 import { SecuredLine } from '@src/core/types';
-import { WalletSelectors } from '@src/core/store';
+import { WalletSelectors, OnchainMetaDataSelector } from '@src/core/store';
 import { getConfig } from '@src/config';
+import { formatAddress, getENS } from '@src/utils';
 const { NETWORK_SETTINGS } = getConfig();
 
 const LineTitle = styled(Text)`
@@ -20,6 +21,7 @@ const RedirectLink = styled(Link)`
 
 const LinkOut = styled(RedirectIcon)`
   fill: ${({ theme }) => theme.colors.primary};
+  height: 1.4rem;
 `;
 
 const CreditLineData = styled.div`
@@ -166,7 +168,7 @@ export const TxCreditLineInput: FC<TxCreditLineInputProps> = ({
 }) => {
   const { t } = useAppTranslation('common');
   const selectedNetwork = useAppSelector(WalletSelectors.selectWalletNetwork);
-  // tODO get borrower ENS
+  const ensMap = useAppSelector(OnchainMetaDataSelector.selectENSPairs);
 
   let listItems: SearchListItem[] = [];
   //let zappableItems: SearchListItem[] = [];
@@ -233,13 +235,14 @@ export const TxCreditLineInput: FC<TxCreditLineInputProps> = ({
           <CreditLineData>
             <RedirectLink to={`${blockExplorerUrl}/address/${selectedCredit.borrower}`}>
               <LineTitle ellipsis>
-                {t('components.transaction.add-credit-input.selected-borrower')}: {selectedCredit.borrower}
+                {t('components.transaction.add-credit-input.selected-borrower')}:
+                {' ' + formatAddress(getENS(selectedCredit.borrower, ensMap)!)}
               </LineTitle>
               <LinkOut />
             </RedirectLink>
             <RedirectLink to={`${blockExplorerUrl}/address/${selectedCredit.id}`}>
               <LineTitle ellipsis>
-                {t('components.transaction.add-credit-input.selected-line')}: {selectedCredit.id}
+                {t('components.transaction.add-credit-input.selected-line')}: {formatAddress(selectedCredit.id)}
               </LineTitle>
               <LinkOut />
             </RedirectLink>

--- a/src/client/components/app/Transactions/components/TxPositionInput.tsx
+++ b/src/client/components/app/Transactions/components/TxPositionInput.tsx
@@ -2,11 +2,12 @@ import { FC, useState } from 'react';
 import styled from 'styled-components';
 import { CSSTransition, TransitionGroup } from 'react-transition-group';
 
-import { useAppTranslation } from '@hooks';
+import { useAppTranslation, useAppSelector } from '@hooks';
 import { Text, Icon, ZapIcon, LogoIcon } from '@components/common';
 import { PositionSearchList } from '@src/client/components/common/PositionSearchList';
+import { OnchainMetaDataSelector } from '@src/core/store';
 import { CreditPosition } from '@src/core/types';
-import { normalizeAmount } from '@src/utils';
+import { normalizeAmount, formatAddress, getENS } from '@src/utils';
 
 import { TokenIcon } from '../../TokenIcon';
 
@@ -23,7 +24,7 @@ const CreditLineData = styled.div`
   border-radius: ${({ theme }) => theme.globalRadius};
   background: ${({ theme }) => theme.colors.txModalColors.backgroundVariant};
   padding: ${({ theme }) => theme.layoutPadding};
-  font-size: 1.7rem;
+  font-size: 1.4rem;
   flex: 1;
 `;
 
@@ -155,6 +156,7 @@ export const TxPositionInput: FC<TxPositionInputProps> = ({
 }) => {
   const { t } = useAppTranslation('common');
   const [openedSearch, setOpenedSearch] = useState(false);
+  const ensMap = useAppSelector(OnchainMetaDataSelector.selectENSPairs);
 
   if (!positions || positions.length < 1) return null;
   const position = selectedPosition || positions[0];
@@ -207,10 +209,9 @@ export const TxPositionInput: FC<TxPositionInputProps> = ({
             <CreditLineName>{position.token.symbol}</CreditLineName>
           </CreditLineSelector>
           <CreditLineData>
-            <LineTitle ellipsis> Lender: {position?.lender} </LineTitle>
+            <LineTitle ellipsis> Lender: {formatAddress(getENS(position?.lender, ensMap)!)} </LineTitle>
             <LineTitle ellipsis>
-              {`${normalizeAmount(position?.deposit, 18)} ${position?.token.symbol}
-              @${position?.dRate}/${position?.fRate}%`}
+              Available: {`${normalizeAmount(position?.deposit, 18)} ${position?.token.symbol}`}
             </LineTitle>
           </CreditLineData>
         </CreditLineInfo>

--- a/src/client/containers/Columns/index.tsx
+++ b/src/client/containers/Columns/index.tsx
@@ -11,7 +11,7 @@ const StyledLayout = styled.div`
   grid-template-columns: repeat(3, 1fr);
   column-gap: ${({ theme }) => theme.spacing.xl};
   justify-content: flex-start;
-  overflow: scroll;
+  // overflow: scroll;
 
   flex: 1;
 

--- a/src/client/containers/Columns/index.tsx
+++ b/src/client/containers/Columns/index.tsx
@@ -11,6 +11,9 @@ const StyledLayout = styled.div`
   grid-template-columns: repeat(3, 1fr);
   column-gap: ${({ theme }) => theme.spacing.xl};
   justify-content: flex-start;
+  // TODO: Add background-color and paddding here
+  // background-color: #000000;
+  // padding: 1.25rem;
   // overflow: scroll;
 
   flex: 1;

--- a/src/client/containers/Modals/WithdrawCreditTxModal/index.tsx
+++ b/src/client/containers/Modals/WithdrawCreditTxModal/index.tsx
@@ -21,7 +21,7 @@ export const WithdrawCreditTxModal: FC<WithdrawTxModalProps> = ({ onClose, ...pr
   const onPositionChange = () => {
     // update deposit params
   };
-
+  console.log('withdraw modal props: ', props);
   return (
     <StyledWithdrawTxModal {...props}>
       <WithdrawCreditTx

--- a/src/client/routes/Market/index.tsx
+++ b/src/client/routes/Market/index.tsx
@@ -151,6 +151,7 @@ export const Market = () => {
         <SpinnerLoading flex="1" width="100%" />
       ) : (
         Object.entries(lineCategoriesForDisplay!).map(([key, val]: [string, SecuredLine[]], i: number) => {
+          console.log('line card val: ', val);
           return (
             <StyledRecommendationsCard
               header={t(key)}

--- a/src/client/routes/Portfolio/index.tsx
+++ b/src/client/routes/Portfolio/index.tsx
@@ -19,11 +19,12 @@ const StyledViewContainer = styled(ViewContainer)`
 
 const PortfolioHeader = styled.div`
   grid-column: 1 / 3;
+  grid-column-gap: ${({ theme }) => theme.spacing.xl};
   display: flex;
   justify-content: space-between;
 
   @media ${device.desktop} {
-    justify-content: space-around;
+    justify-content: flex-start;
   }
 `;
 

--- a/src/client/routes/Portfolio/index.tsx
+++ b/src/client/routes/Portfolio/index.tsx
@@ -88,6 +88,7 @@ export const Portfolio = () => {
   const portfolioAddress = userAddress ? userAddress : userWallet;
   const allPositions = useAppSelector(LinesSelectors.selectPositionsMap);
   const [selectedRole, setRole] = useState<string>(BORROWER_POSITION_ROLE);
+  const lineAddress = useAppSelector(LinesSelectors.selectSelectedLineAddress);
 
   const availableRoles = [BORROWER_POSITION_ROLE, LENDER_POSITION_ROLE];
 
@@ -108,6 +109,7 @@ export const Portfolio = () => {
 
   useEffect(() => {
     if (userPortfolio) {
+      console.log('Portfolio Page - selectedRole: ', selectedRole);
       if (selectedRole === BORROWER_POSITION_ROLE) {
         if (borrowerLineOfCredits && borrowerLineOfCredits[0]) {
           const lineAddress = borrowerLineOfCredits[0].id;
@@ -119,12 +121,14 @@ export const Portfolio = () => {
           const position = lenderPositions[0];
           dispatch(LinesActions.clearSelectedLine());
           dispatch(LinesActions.setSelectedLinePosition({ position }));
+          dispatch(LinesActions.setSelectedLineAddress({ lineAddress: allPositions[position].line }));
         }
       }
     }
   }, [userPortfolio, selectedRole]);
 
-  console.log('portfolio page', selectedRole);
+  console.log('portfolio page - selectedRole', selectedRole);
+  console.log('portfolio page - selectedline', lineAddress);
   return (
     <StyledViewContainer>
       <PortfolioHeader>

--- a/src/client/routes/Portfolio/index.tsx
+++ b/src/client/routes/Portfolio/index.tsx
@@ -109,7 +109,6 @@ export const Portfolio = () => {
 
   useEffect(() => {
     if (userPortfolio) {
-      console.log('Portfolio Page - selectedRole: ', selectedRole);
       if (selectedRole === BORROWER_POSITION_ROLE) {
         if (borrowerLineOfCredits && borrowerLineOfCredits[0]) {
           const lineAddress = borrowerLineOfCredits[0].id;

--- a/src/core/store/modules/modals/modals.reducer.ts
+++ b/src/core/store/modules/modals/modals.reducer.ts
@@ -15,6 +15,7 @@ const modalsReducer = createReducer(modalsInitialState, (builder) => {
   builder.addCase(openModal, (state, { payload: { modalName, modalProps } }) => {
     state.activeModal = modalName;
     state.modalProps = modalProps || {};
+    console.log('hello I opened a modal');
 
     // // TODO Move scroll lock into the actions or an effect watcher in react component
     document.body.style.top = `-${window.scrollY}px`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -8893,6 +8893,11 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
+date-fns@^2.29.3:
+  version "2.29.3"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.3.tgz#27402d2fc67eb442b511b70bbdf98e6411cd68a8"
+  integrity sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==
+
 dayjs@^1.11.2:
   version "1.11.3"
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.3.tgz#4754eb694a624057b9ad2224b67b15d552589258"


### PR DESCRIPTION
## Description

**Completed in this PR:**
- [x] Add `Origination` and `Maturity` fields to the Market and Line Pages
- [x] Deploy line modal does not disappear when there is a txn error or user rejects txn
- [x] by default, the repay modal autopopulates with the max repayment amount with both principal and interest.
- [x] borrower cannot change token for repayment in Repay modal.
- [x] labels for deposit collateral modal.
- [x] add ENS name to Propose Position modal.
- [x] setSelectedLinePosition when on Lender tab of portfolio page.
- [x] withdraw modal works from the portfolio page.
- [x] remove scroll bars from line page.
- [x] incorporate changes from Kiba's PR to Portfolio Page style.
- [x] create new labels for create line modal.


## Related Issue

**Notion:**
- [Frontend Bugs - V2](https://www.notion.so/debtdao/Frontend-Bugs-V2-ce6725bdb71a42209698da8281cc31e8)
- [Add Metadata to Market and Line Pages](https://www.notion.so/debtdao/Add-Metadata-to-Market-and-Line-Pages-ad5b6b4124774be195e194059e66c003)

## Motivation and Context

Onboard users with our frontend.

## How Has This Been Tested?

Manual testing.

## Screenshots (if appropriate):
