### PR TITLE
cleanupline metadata ui

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -378,7 +378,6 @@
     "discord": "Discord",
     "docs": "Docs",
     "market": "Market",
-    "lines": "Line Of Credit",
     "portfolio": "Portfolio",
     "settings": "Settings",
     "vault": "Vaults",
@@ -386,7 +385,7 @@
     "wallet": "Wallet"
   },
   "pages": {
-    "market": "Debt DAO Credit Market",
+    "market": "Debt DAO's Cryptonative Credit Marketplace",
     "lines": "Line Of Credit",
     "spigot": "Spigot",
     "portfolio": "Credit Investment Portfolio",

--- a/public/locales/en/lineDetails.json
+++ b/public/locales/en/lineDetails.json
@@ -10,7 +10,7 @@
     "deposit": "Credit Limit",
     "total-interest-paid": "Lifetime Interest Paid",
     "revenue-split":"Revenue Split",
-    "min-cratio":"Minimum Collateralization Ratio",
+    "min-cratio":"Min. Collateralization Ratio",
     "cratio":"Collateralization Ratio",
     "secured-by": "Secured By ",
     "unsecured": "This is an unsecured line of credit. You MUST trust the borrower.",

--- a/public/locales/en/market.json
+++ b/public/locales/en/market.json
@@ -1,7 +1,7 @@
 {
     "banner": {
-      "title": "Debt DAO is the one stop shop for cryptonative credit.",
-      "body": "Secured lending solutions that are fully onchain, fully trustless, and fully anonymous",
+      "title": "Trustless & anonymous secured lending for financing cryptonative entities.",
+      "body": "An open, permissionless, onchain marketplace for DAOs and DeFi protocols to borrow from future cash flows for the first time ever.",
       "cta-lender": "Lender FAQ",
       "cta-borrower": "Get Credit"
     },

--- a/src/client/components/app/LineDetailsDisplay/LineMetadata.tsx
+++ b/src/client/components/app/LineDetailsDisplay/LineMetadata.tsx
@@ -150,23 +150,15 @@ interface MetricDisplay extends Metric {
   title: string;
   data: string;
   displaySubmetrics?: boolean;
-  submetrics?: Metric[];
+  children?: any;
 }
 
-const MetricDataDisplay = ({ title, data, displaySubmetrics = false, submetrics }: MetricDisplay) => {
+const MetricDataDisplay = ({ title, data, displaySubmetrics = false, children }: MetricDisplay) => {
   return (
     <MetricContainer>
       <MetricName>{title}</MetricName>
       <DataMetric>{data}</DataMetric>
-      {displaySubmetrics && (
-        <DataSubMetricsContainer>
-          {submetrics?.map(({ title, data }, index) => (
-            <DataSubMetric key={index}>
-              {title} : {data}
-            </DataSubMetric>
-          ))}
-        </DataSubMetricsContainer>
-      )}
+      {displaySubmetrics && <DataSubMetricsContainer>{children}</DataSubMetricsContainer>}
     </MetricContainer>
   );
 };
@@ -216,12 +208,26 @@ export const LineMetadata = () => {
     if (!revenue) return null;
     return (
       <>
-        <MetricDataDisplay
-          title={t('lineDetails:metadata.revenue-split')}
-          data={`${t('lineDetails:metadata.lender')} ${defaultSplit}%  --  ${t('lineDetails:metadata.borrower')} ${
-            100 - Number(defaultSplit)
-          }% `}
-        />
+        <div>
+          <p>
+            <MetadataTitle>
+              {`${t('lineDetails:metadata.lender')}  ${t('lineDetails:metadata.revenue-split')}`}:
+            </MetadataTitle>{' '}
+            {defaultSplit}%
+          </p>
+          <p>
+            <MetadataTitle>
+              {`${t('lineDetails:metadata.borrower')}  ${t('lineDetails:metadata.revenue-split')}`}:
+            </MetadataTitle>{' '}
+            {100 - Number(defaultSplit)}%
+          </p>
+          <p>
+            <MetadataTitle>{t('lineDetails:metadata.cratio')}: </MetadataTitle> {cratio}%
+          </p>
+          <p>
+            <MetadataTitle>{t('lineDetails:metadata.min-cratio')}: </MetadataTitle> {minCRatio}%
+          </p>
+        </div>
         <MetricDataDisplay
           title={t('lineDetails:metadata.revenue.total')}
           data={`$ ${humanize('amount', revenueValue, 18, 2)}`}
@@ -372,11 +378,6 @@ export const LineMetadata = () => {
   return (
     <>
       <ThreeColumnLayout>
-        <MetricDataDisplay
-          title={t('lineDetails:metadata.principal')}
-          data={`$ ${humanize('amount', principal, 18, 2)}`}
-        />
-        <MetricDataDisplay title={t('lineDetails:metadata.deposit')} data={`$ ${humanize('amount', deposit, 18, 2)}`} />
         <MetadataBox>
           <p>
             <MetadataTitle>{t('lineDetails:metadata.status')}: </MetadataTitle>{' '}
@@ -392,13 +393,12 @@ export const LineMetadata = () => {
             <MetadataTitle>{t('lineDetails:metadata.total-interest-paid')}: </MetadataTitle> $
             {humanize('amount', totalInterestRepaid, 18, 2)}
           </p>
-          <p>
-            <MetadataTitle>{t('lineDetails:metadata.min-cratio')}: </MetadataTitle> {minCRatio}%
-          </p>
-          <p>
-            <MetadataTitle>{t('lineDetails:metadata.cratio')}: </MetadataTitle> {cratio}%
-          </p>
         </MetadataBox>
+        <MetricDataDisplay
+          title={t('lineDetails:metadata.principal')}
+          data={`$ ${humanize('amount', principal, 18, 2)}`}
+        />
+        <MetricDataDisplay title={t('lineDetails:metadata.deposit')} data={`$ ${humanize('amount', deposit, 18, 2)}`} />
       </ThreeColumnLayout>
       <SectionHeader>
         {t('lineDetails:metadata.secured-by')}

--- a/src/client/components/app/LineDetailsDisplay/LineMetadata.tsx
+++ b/src/client/components/app/LineDetailsDisplay/LineMetadata.tsx
@@ -19,6 +19,11 @@ import {
   RevenueSummary,
   SpigotRevenueContractMap,
   TokenView,
+  UNINITIALIZED_STATUS,
+  ACTIVE_STATUS,
+  LIQUIDATABLE_STATUS,
+  REPAID_STATUS,
+  INSOLVENT_STATUS,
 } from '@src/core/types';
 import { DetailCard, ActionButtons, TokenIcon, ViewContainer } from '@components/app';
 import { Button, Text, RedirectIcon, Link, CardEmptyList } from '@components/common';
@@ -71,6 +76,32 @@ const DataMetric = styled.h5`
   ${({ theme }) => `
     font-size: ${theme.fonts.sizes.md};
   `}
+`;
+
+const MetadataBox = styled.div`
+  ${({ theme }) => `
+    font-size: ${theme.fonts.sizes.md};
+  `}
+`;
+
+const MetadataTitle = styled.span`
+  ${({ theme }) => `color: ${theme.colors.primary}; `}
+`;
+
+const StatusWithColor = styled.span<{ status: string }>`
+  color: ${({ status }) => {
+    console.log('stats color', status);
+    switch (status) {
+      case UNINITIALIZED_STATUS:
+        return '#E6E600'; // darkish yellow
+      case ACTIVE_STATUS:
+      case REPAID_STATUS:
+        return '#6AFF4D'; // light green
+      case INSOLVENT_STATUS:
+      case LIQUIDATABLE_STATUS:
+        return '#FF1919'; // bright red
+    }
+  }};
 `;
 
 const DataSubMetricsContainer = styled.div``;
@@ -184,15 +215,22 @@ export const LineMetadata = () => {
   const renderSpigotMetadata = () => {
     if (!revenue) return null;
     return (
-      <MetricDataDisplay
-        title={t('lineDetails:metadata.revenue.total')}
-        data={`$ ${humanize('amount', revenueValue, 18, 2)}`}
-      />
+      <>
+        <MetricDataDisplay
+          title={t('lineDetails:metadata.revenue-split')}
+          data={`${t('lineDetails:metadata.lender')} ${defaultSplit}%  --  ${t('lineDetails:metadata.borrower')} ${
+            100 - Number(defaultSplit)
+          }% `}
+        />
+        <MetricDataDisplay
+          title={t('lineDetails:metadata.revenue.total')}
+          data={`$ ${humanize('amount', revenueValue, 18, 2)}`}
+        />
+      </>
     );
   };
 
-  // TODO: rename to addCollateralHandler
-  const depositHandler = (token: TokenView) => {
+  const addCollateralHandler = (token: TokenView) => {
     if (!walletIsConnected) {
       connectWallet();
     } else {
@@ -201,8 +239,7 @@ export const LineMetadata = () => {
     }
   };
 
-  // TODO: rename to releaseCollateralhandler
-  const withdrawHandler = (token: TokenView) => {
+  const releaseCollateralhandler = (token: TokenView) => {
     if (!walletIsConnected) {
       connectWallet();
     } else {
@@ -249,17 +286,18 @@ export const LineMetadata = () => {
     actions: getCollateralRowActionForRole(userPositionMetadata.role),
   }));
 
+  const connectWalletText = t('components.connect-button.connect');
   const enableCollateralText = walletIsConnected
-    ? `${t('lineDetails:metadata.collateral-table.enable-asset')}`
-    : `${t('components.connect-button.connect')}`;
+    ? t('lineDetails:metadata.collateral-table.enable-asset')
+    : connectWalletText;
 
   const enableSpigotText = walletIsConnected
-    ? `${t('lineDetails:metadata.collateral-table.enable-spigot')}`
-    : `${t('components.connect-button.connect')}`;
+    ? t('lineDetails:metadata.collateral-table.enable-spigot')
+    : connectWalletText;
 
   const depositCollateralText = walletIsConnected
-    ? `${t('lineDetails:metadata.collateral-table.add-collateral')}`
-    : `${t('components.connect-button.connect')}`;
+    ? t('lineDetails:metadata.collateral-table.add-collateral')
+    : connectWalletText;
 
   const getCollateralTableActions = () => {
     switch (userPositionMetadata.role) {
@@ -282,12 +320,13 @@ export const LineMetadata = () => {
 
   const startDateHumanized = format(new Date(startTime * 1000), 'MMMM dd, yyyy');
   const endDateHumanized = format(new Date(endTime * 1000), 'MMMM dd, yyyy');
-  const revenueSplitFormatted: Metric[] = [];
-  revenueSplitFormatted.push({
-    title: `${t('lineDetails:metadata.borrower')}`,
-    data: 100 - Number(defaultSplit) + '%',
-  });
-  revenueSplitFormatted.push({ title: `${t('lineDetails:metadata.lender')}`, data: defaultSplit + '%' });
+  const revenueSplitFormatted: Metric[] = [
+    { title: `${t('lineDetails:metadata.lender')}`, data: defaultSplit + '%' },
+    {
+      title: `${t('lineDetails:metadata.borrower')}`,
+      data: 100 - Number(defaultSplit) + '%',
+    },
+  ];
 
   // TODO: fix types on args
   // TODO: What is the action button for revenue?
@@ -302,12 +341,12 @@ export const LineMetadata = () => {
           actions={[
             {
               name: t('components.transaction.deposit'),
-              handler: () => depositHandler(token),
+              handler: () => addCollateralHandler(token),
               disabled: !walletIsConnected,
             },
             {
               name: t('components.transaction.release'),
-              handler: () => withdrawHandler(token),
+              handler: () => releaseCollateralhandler(token),
               disabled: !walletIsConnected,
             },
           ]}
@@ -328,6 +367,8 @@ export const LineMetadata = () => {
     // );
     return;
   };
+
+  console.log('Metadata staus', status);
   return (
     <>
       <ThreeColumnLayout>
@@ -336,24 +377,28 @@ export const LineMetadata = () => {
           data={`$ ${humanize('amount', principal, 18, 2)}`}
         />
         <MetricDataDisplay title={t('lineDetails:metadata.deposit')} data={`$ ${humanize('amount', deposit, 18, 2)}`} />
-        <MetricDataDisplay
-          title={t('lineDetails:metadata.total-interest-paid')}
-          data={`$ ${humanize('amount', totalInterestRepaid, 18, 2)}`}
-        />
-        <MetricDataDisplay
-          title={t('lineDetails:metadata.revenue-split')}
-          data={''}
-          displaySubmetrics={true}
-          submetrics={revenueSplitFormatted}
-        />
-        <MetricDataDisplay title={t('lineDetails:metadata.min-cratio')} data={minCRatio + '%'} />
-        <MetricDataDisplay title={t('lineDetails:metadata.cratio')} data={cratio + '%'} />
-        <MetricDataDisplay
-          title={t('lineDetails:metadata.status')}
-          data={status[0].toUpperCase() + status.substring(1)}
-        />
-        <MetricDataDisplay title={t('lineDetails:metadata.start')} data={startDateHumanized} />
-        <MetricDataDisplay title={t('lineDetails:metadata.end')} data={endDateHumanized} />
+        <MetadataBox>
+          <p>
+            <MetadataTitle>{t('lineDetails:metadata.status')}: </MetadataTitle>{' '}
+            <StatusWithColor status={status}>{status[0].toUpperCase() + status.substring(1)}</StatusWithColor>{' '}
+          </p>
+          <p>
+            <MetadataTitle>{t('lineDetails:metadata.start')}: </MetadataTitle> {startDateHumanized}
+          </p>
+          <p>
+            <MetadataTitle>{t('lineDetails:metadata.end')}: </MetadataTitle> {endDateHumanized}
+          </p>
+          <p>
+            <MetadataTitle>{t('lineDetails:metadata.total-interest-paid')}: </MetadataTitle> $
+            {humanize('amount', totalInterestRepaid, 18, 2)}
+          </p>
+          <p>
+            <MetadataTitle>{t('lineDetails:metadata.min-cratio')}: </MetadataTitle> {minCRatio}%
+          </p>
+          <p>
+            <MetadataTitle>{t('lineDetails:metadata.cratio')}: </MetadataTitle> {cratio}%
+          </p>
+        </MetadataBox>
       </ThreeColumnLayout>
       <SectionHeader>
         {t('lineDetails:metadata.secured-by')}

--- a/src/client/components/app/LineDetailsDisplay/LineMetadata.tsx
+++ b/src/client/components/app/LineDetailsDisplay/LineMetadata.tsx
@@ -104,6 +104,14 @@ const StatusWithColor = styled.span<{ status: string }>`
   }};
 `;
 
+const CratioWithColor = styled.span<{ diff: number }>`
+  color: ${({ diff }) => {
+    if (diff >= 15) return '#6AFF4D'; // decent margin - light green
+    else if (diff < 0) return '#FF1919'; // liquidatable - bright red
+    else return '#E6E600'; // close to liquidatable - darkish yellow
+  }};
+`;
+
 const DataSubMetricsContainer = styled.div``;
 
 const DataSubMetric = styled.p``;
@@ -222,7 +230,8 @@ export const LineMetadata = () => {
             {100 - Number(defaultSplit)}%
           </p>
           <p>
-            <MetadataTitle>{t('lineDetails:metadata.cratio')}: </MetadataTitle> {cratio}%
+            <MetadataTitle>{t('lineDetails:metadata.cratio')}: </MetadataTitle>{' '}
+            <CratioWithColor diff={Number(cratio) - Number(minCRatio)}>{cratio}%</CratioWithColor>
           </p>
           <p>
             <MetadataTitle>{t('lineDetails:metadata.min-cratio')}: </MetadataTitle> {minCRatio}%

--- a/src/client/components/app/Transactions/DeployLineTx.tsx
+++ b/src/client/components/app/Transactions/DeployLineTx.tsx
@@ -232,6 +232,7 @@ export const DeployLineTx: FC<DeployLineProps> = (props) => {
           <TxNumberInput
             headerText={t('components.transaction.deploy-line.cratio')}
             inputLabel={t('components.transaction.deploy-line.cratio-input')}
+            inputAlign="right"
             width={'sm'}
             placeholder={'30%'}
             amount={cratio}
@@ -244,6 +245,7 @@ export const DeployLineTx: FC<DeployLineProps> = (props) => {
           <TxNumberInput
             headerText={t('components.transaction.deploy-line.revenue-split')}
             inputLabel={t('components.transaction.deploy-line.revenue-split-input')}
+            inputAlign="right"
             width={'sm'}
             placeholder={'90%'}
             amount={revenueSplit}

--- a/src/client/components/app/Transactions/components/TxNumberInput.tsx
+++ b/src/client/components/app/Transactions/components/TxNumberInput.tsx
@@ -13,7 +13,7 @@ const InterestRateInputContainer = styled.div`
   flex-direction: row;
 `;
 
-const StyledAmountInput = styled.input<{ readOnly?: boolean; error?: boolean }>`
+const StyledAmountInput = styled.input<{ textAlign: string; readOnly?: boolean; error?: boolean }>`
   font-size: 2.4rem;
   font-weight: 700;
   background: transparent;
@@ -23,7 +23,8 @@ const StyledAmountInput = styled.input<{ readOnly?: boolean; error?: boolean }>`
   padding: 0;
   font-family: inherit;
   appearance: textfield;
-  width: 80%;
+  width: 50%;
+  text-align: ${({ textAlign }) => textAlign};
 
   &::placeholder {
     color: ${({ theme }) => theme.colors.txModalColors.textContrast};
@@ -120,6 +121,7 @@ export interface TxNumberInputProps {
   headerText?: string;
   inputLabel?: string;
   width?: 'sm' | 'md';
+  inputAlign?: 'left' | 'right';
   placeholder?: string;
   amount: string;
   maxAmount?: string;
@@ -141,6 +143,7 @@ export const TxNumberInput: FC<TxNumberInputProps> = ({
   readOnly,
   hideAmount,
   children,
+  inputAlign = 'left',
   ...props
 }) => {
   return (
@@ -162,6 +165,7 @@ export const TxNumberInput: FC<TxNumberInputProps> = ({
                     error={inputError}
                     type="number"
                     aria-label={inputLabel || ''}
+                    textAlign={inputAlign}
                   />
                   <InputPercent>%</InputPercent>
                 </InterestRateInputContainer>


### PR DESCRIPTION
## Description

- simplifies above the fold UI on line page
- Moves most metadata to a tiny box in the corner

adds colors for vital info like current status and cratio for easy readability at a glance

### Before
<img width="1204" alt="Screenshot 2023-02-03 at 2 17 04 PM" src="https://user-images.githubusercontent.com/22554244/216688676-b84fe64d-cd8c-4928-95fb-f721c9c1b943.png">
### After
<img width="1117" alt="Screenshot 2023-02-03 at 2 57 35 PM" src="https://user-images.githubusercontent.com/22554244/216698442-8a97a5a4-c599-4bac-bd80-698a7ccf1653.png">


## Motivation and Context

Haven't liked it since metadata got added. Hasseeb confirmed its shit.

## How Has This Been Tested?

visual acuity

